### PR TITLE
Update docker container to run as non-root user

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,40 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set Docker Tag
+        id: docker-tag
+        run: echo "DOCKER_TAG=${GITHUB_SHA:0:7}-$(date +%s)" | tee $GITHUB_ENV
+
+      - name: Login to Docker Repository
+        uses: docker/login-action@v1
+        with:
+          registry: core-harbor.us-east-2.codefi.network
+          username: ${{ secrets.DOCKER_REPO_USER }}
+          password: ${{ secrets.DOCKER_REPO_TOKEN }}
+
+      - name: Docker Image Build
+        id: docker-build
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          tags: core-harbor.us-east-2.codefi.network/palm/palm-gnosis-safe-ui:${{ env.DOCKER_TAG }}
+
+      - name: Docker Image Build and Publish
+        id: docker-build-publish
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: core-harbor.us-east-2.codefi.network/palm/palm-gnosis-safe-ui:${{ env.DOCKER_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,25 @@
-FROM nginx
-COPY app/* /usr/share/nginx/html
+FROM nginx:1.21-alpine
+
+# Remove nginx user
+RUN sed -i '/^user.*nginx;/d' /etc/nginx/nginx.conf
+
+# Update default port to 3000
+RUN sed -i 's/\(listen.*\)80;/\13000;/g' /etc/nginx/conf.d/default.conf
+
+# Update permission on paths
+RUN chown -R nginx:nginx /usr/share/nginx/html && \
+    chown -R nginx:nginx /var/cache/nginx && \
+    chown -R nginx:nginx /var/log/nginx && \
+    chown -R nginx:nginx /etc/nginx/conf.d && \
+    touch /var/run/nginx.pid && \
+    chown -R nginx:nginx /var/run/nginx.pid
+
+# Expose on a port above 1024
+EXPOSE 3000
+
+# Run as nginx user
+USER nginx
+
+# Copy application files
+COPY app/* /usr/share/nginx/html/
+


### PR DESCRIPTION
Nginx by default run as root user. This is because it is designed to run on port 80. Updated the container image build so that it runs as nginx user and serve over port 3000
Added CI docker build pipeline where docker image is build when a pull request is created/updated. Image published when push on main or PR is merged to main