### PR TITLE
Fix: condition update to build and publish when git ref is a tag

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Docker Image Build and Publish
         id: docker-build-publish
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/tags/') }}
         uses: docker/build-push-action@v2
         with:
           push: true


### PR DESCRIPTION
Git ref value is different for event created with release. Updated if condition so that docker tag created when git tag is created